### PR TITLE
Counter & test updates

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -275,7 +275,7 @@ const parameterizedSelectorFactory = (innerFn, overrideOptions = {}) => {
 
       // If canUsePreviousResult is true at this point then we've matched scenario A above
 
-      if (!canUsePreviousResult && !isRootSelector && hasStaticDependencies && previousResult.dependencies.length > 0) {
+      if (!canUsePreviousResult && !isRootSelector && previousResult.dependencies.length > 0) {
         // We need to check the prior dependencies to see if they've actually changed.
         // @TODO: Need to warn if a root selector has/calls any dependencies
         if (options.verboseLoggingEnabled) {
@@ -391,7 +391,7 @@ const parameterizedSelectorFactory = (innerFn, overrideOptions = {}) => {
         dependencies: (hasStaticDependencies && previousResult) ? previousResult.dependencies : [],
         returnValue: null,
         // Note that these counts will get overwritten immediately below (if performance checks are on)
-        callCount: 0,
+        callCount: 1,
         recomputationCount: 0,
       };
 

--- a/src/index.js
+++ b/src/index.js
@@ -401,6 +401,14 @@ const parameterizedSelectorFactory = (innerFn, overrideOptions = {}) => {
           totalRecomputationCount += 1;
           newResult.callCount = previousResult.callCount + 1;
           newResult.recomputationCount = previousResult.recomputationCount + 1;
+
+          // While we're here, let's make sure the selector isn't recomputing too often.
+          // @TODO: Is it worth making an option for this 75% value?
+          if (newResult.callCount > 2 && newResult.recomputationCount > 0.75 * newResult.callCount) {
+            options.performanceChecksCallback(`${verboseLoggingPrefix} is recomputing a lot: ${newResult.recomputationCount} of ${newResult.callCount} runs.`);
+          } else if (totalCallCount > 5 && totalRecomputationCount > 0.75 * totalCallCount) {
+            options.performanceChecksCallback(`${options.displayName} is recomputing a lot in total: ${totalRecomputationCount} of ${totalCallCount} runs.`);
+          }
         }
       }
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,53 +3,6 @@
 import isEmpty from 'lodash/isEmpty';
 import isPlainObject from 'lodash/isPlainObject';
 
-//
-// Internal setup and bookkeeping
-//
-
-const willThrowErrorIfNotSet = label => () => {
-  throw new Error(`parameterizedSelector: ${label} must be set.`);
-};
-
-const defaultOptions = {
-  // Some options can only be set at initialization
-  displayNamePrefix: 'parameterizedSelector',
-  createKeyFromParams: willThrowErrorIfNotSet('createKeyFromParams'),
-  compareIncomingStates: willThrowErrorIfNotSet('compareIncomingStates'),
-  compareSelectorResults: willThrowErrorIfNotSet('compareSelectorResults'),
-  isRootSelector: willThrowErrorIfNotSet('isRootSelector'),
-  hasStaticDependencies: false,
-
-  // Some options can be changed anytime
-  displayName: null,
-  useConsoleGroup: true,
-  verboseLoggingEnabled: false,
-  verboseLoggingCallback: console.log, /* eslint-disable-line no-console */
-  performanceChecksEnabled: (typeof __DEV__ !== 'undefined' && !!__DEV__),
-  performanceChecksCallback: console.log, /* eslint-disable-line no-console */
-  warningsEnabled: true,
-  warningsCallback: console.warn, /* eslint-disable-line no-console */
-};
-
-/**
- * When a parameterizedSelector is run, we'll add it to this stack so that *other* parameterizedSelectors
- * can register themselves as dependencies for it. This let us know which dependencies to dirty-check
- * the next time it runs.
- */
-const parameterizedSelectorCallStack = [];
-
-/**
- * Here we can track the number of recomputations due to cache misses, state changes, param changes etc
- * primarily used for performance and unit-testing purposes
- */
-let recomputations = 0;
-
-/**
- * Each selector needs a unique displayName. We'll pull that from options or the innerFn if possible,
- * but if we have to fall back to raw numbers we'll use this counter to keep them distinct.
- */
-let unnamedCount = 0;
-
 
 //
 // Presets
@@ -131,6 +84,63 @@ const KEY_PRESETS = {
 
 
 //
+// Internal setup and bookkeeping
+//
+
+const willThrowErrorIfNotSet = label => () => {
+  throw new Error(`parameterizedSelector: ${label} must be set.`);
+};
+
+/**
+ * Defaults for individual options are exported on their own, so that they can be referenced if the caller ever
+ * needs to reference the original value, after setting new defaults.
+ */
+const defaultInitialOptions = {
+  displayNamePrefix: 'parameterizedSelector',
+  compareIncomingStates: COMPARISON_PRESETS.SAME_REFERENCE,
+  compareSelectorResults: COMPARISON_PRESETS.SAME_REFERENCE_OR_EMPTY,
+  exceptionCallback: (errorMessage, error) => {
+    console.error(errorMessage, error);
+    throw error;
+  },
+};
+
+const defaultOptions = {
+  // Some options can only be set at initialization
+  displayNamePrefix: defaultInitialOptions.displayNamePrefix,
+  createKeyFromParams: willThrowErrorIfNotSet('createKeyFromParams'),
+  compareIncomingStates: defaultInitialOptions.compareIncomingStates,
+  compareSelectorResults: defaultInitialOptions.compareSelectorResults,
+  isRootSelector: willThrowErrorIfNotSet('isRootSelector'),
+  hasStaticDependencies: false,
+
+  // Some options can be changed anytime
+  displayName: null,
+  useConsoleGroup: true,
+  verboseLoggingEnabled: false,
+  verboseLoggingCallback: console.log, /* eslint-disable-line no-console */
+  performanceChecksEnabled: (typeof __DEV__ !== 'undefined' && !!__DEV__),
+  performanceChecksCallback: console.log, /* eslint-disable-line no-console */
+  warningsEnabled: true,
+  warningsCallback: console.warn, /* eslint-disable-line no-console */
+  exceptionCallback: defaultInitialOptions.exceptionCallback,
+};
+
+/**
+ * When a parameterizedSelector is run, we'll add it to this stack so that *other* parameterizedSelectors
+ * can register themselves as dependencies for it. This let us know which dependencies to dirty-check
+ * the next time it runs.
+ */
+const parameterizedSelectorCallStack = [];
+
+/**
+ * Each selector needs a unique displayName. We'll pull that from options or the innerFn if possible,
+ * but if we have to fall back to raw numbers we'll use this counter to keep them distinct.
+ */
+let unnamedCount = 0;
+
+
+//
 // Exported functions
 //
 
@@ -176,6 +186,16 @@ const parameterizedSelectorFactory = (innerFn, overrideOptions = {}) => {
    */
   const previousResultsByParam = {};
 
+  /**
+   * Here we can track the number of recomputations due to cache misses, state changes, param changes etc,
+   * and the number of times the selector was ever called (regardless of whether it recomputed.)
+   * This is primarily used for performance and unit-testing purposes.
+   *
+   * Note that these counts apply to ALL params. There is a separate set of per-param counters, tracked in
+   * the previousResults.
+   */
+  let totalCallCount = 0;
+  let totalRecomputationCount = 0;
 
   /**
    * This performs some standard argument-massaging and inspects the previous result (if any) to determine
@@ -252,8 +272,6 @@ const parameterizedSelectorFactory = (innerFn, overrideOptions = {}) => {
           options.verboseLoggingCallback(`${verboseLoggingPrefix} doesn't need to re-run because state didn't change`);
         }
       }
-
-      recomputations++
 
       // If canUsePreviousResult is true at this point then we've matched scenario A above
 
@@ -360,6 +378,11 @@ const parameterizedSelectorFactory = (innerFn, overrideOptions = {}) => {
 
     let returnValue;
     if (canUsePreviousResult) {
+      if (options.performanceChecksEnabled) {
+        totalCallCount += 1;
+        previousResult.callCount += 1;
+      }
+
       ({ returnValue } = previousResult);
     } else {
       const newResult = {
@@ -367,7 +390,19 @@ const parameterizedSelectorFactory = (innerFn, overrideOptions = {}) => {
         recordDependencies: !(hasStaticDependencies && previousResult),
         dependencies: (hasStaticDependencies && previousResult) ? previousResult.dependencies : [],
         returnValue: null,
+        // Note that these counts will get overwritten immediately below (if performance checks are on)
+        callCount: 0,
+        recomputationCount: 0,
       };
+
+      if (options.performanceChecksEnabled) {
+        totalCallCount += 1;
+        if (previousResult) {
+          totalRecomputationCount += 1;
+          newResult.callCount = previousResult.callCount + 1;
+          newResult.recomputationCount = previousResult.recomputationCount + 1;
+        }
+      }
 
       // Collect dependencies, if appropriate
       parameterizedSelectorCallStack.push(newResult);
@@ -451,7 +486,21 @@ const parameterizedSelectorFactory = (innerFn, overrideOptions = {}) => {
     return canUsePreviousResult;
   };
 
-  parameterizedSelector.getRecomputations = () => recomputations
+  parameterizedSelector.getTotalCallCount = () => totalCallCount;
+  parameterizedSelector.getTotalRecomputations = () => totalRecomputationCount;
+
+  parameterizedSelector.getCallCountForParams = (keyParams) => {
+    const keyParamsString = createKeyFromParams(keyParams);
+    const previousResult = previousResultsByParam[keyParamsString];
+
+    return previousResult ? previousResult.callCount : 0;
+  };
+  parameterizedSelector.getRecomputationsForParams = (keyParams) => {
+    const keyParamsString = createKeyFromParams(keyParams);
+    const previousResult = previousResultsByParam[keyParamsString];
+
+    return previousResult ? previousResult.recomputationCount : 0;
+  };
 
   parameterizedSelector.isParameterizedSelector = true;
   parameterizedSelector.displayName = options.displayName;
@@ -486,6 +535,7 @@ const createParameterizedSelector = parameterizedSelectorFactory.withOptions({
 export {
   KEY_PRESETS,
   COMPARISON_PRESETS,
+  defaultInitialOptions,
   parameterizedSelectorFactory,
   createParameterizedRootSelector,
   createParameterizedSelector,

--- a/tests/functional-scenarios.js
+++ b/tests/functional-scenarios.js
@@ -1,0 +1,297 @@
+/* eslint-env mocha */
+import chai from 'chai';
+
+import {
+  COMPARISON_PRESETS,
+  createParameterizedRootSelector,
+  createParameterizedSelector,
+} from '../src/index';
+
+const assert = chai.assert; // eslint-disable-line prefer-destructuring
+
+describe('Selectors for single objects', () => {
+  const initialState = {
+    authorDataById: {
+      1: { name: 'Alice' },
+      2: { name: 'Bob' },
+      3: { name: 'Chris' },
+    },
+    bookDataById: {
+      101: { title: 'Alphabet', authorId: 1 },
+      102: { title: 'Binding', authorId: 2 },
+      103: { title: 'Chapter', authorId: 1 },
+      104: { title: 'Dewey Decimal', authorId: 2 },
+    },
+    bookIdsByAuthorId: {
+      1: [101, 103],
+      2: [102, 104],
+      3: [],
+    },
+  };
+
+  let selectRawAuthorData;
+  let selectRawBookData;
+  let selectAuthor;
+  let selectBook;
+  let selectAuthorForBook;
+
+  beforeEach(() => {
+    // The selectors get recreated for each test, to reset their call counts.
+    // The root selector just returns the raw data in the state, while the selector that's built on top
+    // of it will add in some additional fields.
+    selectRawAuthorData = createParameterizedRootSelector(
+      (state, authorId) => state.authorDataById[authorId],
+      {
+        displayName: 'selectRawAuthorData',
+        compareSelectorResults: COMPARISON_PRESETS.SHALLOW_EQUAL,
+        performanceChecksEnabled: true,
+      },
+    );
+    selectRawBookData = createParameterizedRootSelector(
+      (state, bookId) => state.bookDataById[bookId],
+      {
+        displayName: 'selectRawBookData',
+        compareSelectorResults: COMPARISON_PRESETS.SHALLOW_EQUAL,
+        performanceChecksEnabled: true,
+      },
+    );
+
+    // By convention in this test only, root selectors receive an ID directly while intermediate selectors
+    // receive a params object.
+    selectAuthor = createParameterizedSelector(
+      ({ authorId }) => {
+        const rawAuthorData = selectRawAuthorData(authorId);
+        if (!rawAuthorData) {
+          return null;
+        }
+        const name = (rawAuthorData.name || '').trim();
+        return {
+          ...rawAuthorData,
+          authorId,
+          name,
+          nameLowerCase: name.toLowerCase(),
+        };
+      },
+      {
+        displayName: 'selectAuthor',
+        compareSelectorResults: COMPARISON_PRESETS.SHALLOW_EQUAL,
+        performanceChecksEnabled: true,
+      },
+    );
+    selectBook = createParameterizedSelector(
+      ({ bookId }) => {
+        const rawBookData = selectRawBookData(bookId);
+        if (!rawBookData) {
+          return null;
+        }
+        const title = (rawBookData.title || '').trim();
+        return {
+          ...rawBookData,
+          bookId,
+          title,
+          titleLowerCase: title.toLowerCase(),
+        };
+      },
+      {
+        displayName: 'selectBook',
+        compareSelectorResults: COMPARISON_PRESETS.SHALLOW_EQUAL,
+        performanceChecksEnabled: true,
+      },
+    );
+
+    selectAuthorForBook = createParameterizedSelector(
+      (params) => {
+        const book = selectBook(params);
+        if (!book || !book.authorId) {
+          return null;
+        }
+        return selectAuthor({ authorId: book.authorId });
+      },
+      {
+        displayName: 'selectAuthorForBook',
+        performanceChecksEnabled: true,
+      },
+    );
+  });
+
+
+  it('should return author models', () => {
+    const firstAuthor = selectAuthor(initialState, { authorId: 1 });
+    const secondAuthor = selectAuthor(initialState, { authorId: 2 });
+
+    assert.equal(firstAuthor.authorId, 1);
+    assert.equal(firstAuthor, selectAuthor(initialState, { authorId: 1 }));
+    assert.equal(secondAuthor.authorId, 2);
+    assert.equal(secondAuthor, selectAuthor(initialState, { authorId: 2 }));
+
+    assert.equal(selectAuthor.getCallCountForParams({ authorId: 1 }), 2);
+    assert.equal(selectAuthor.getRecomputationsForParams({ authorId: 1 }), 0);
+    assert.equal(selectAuthor.getCallCountForParams({ authorId: 2 }), 2);
+    assert.equal(selectAuthor.getRecomputationsForParams({ authorId: 2 }), 0);
+  });
+  it('should return book models', () => {
+    const firstBook = selectBook(initialState, { bookId: 101 });
+    const secondBook = selectBook(initialState, { bookId: 102 });
+    const thirdBook = selectBook(initialState, { bookId: 103 });
+    const fourthBook = selectBook(initialState, { bookId: 104 });
+
+    assert.equal(firstBook.bookId, 101);
+    assert.equal(firstBook, selectBook(initialState, { bookId: 101 }));
+    assert.equal(secondBook.bookId, 102);
+    assert.equal(secondBook, selectBook(initialState, { bookId: 102 }));
+    assert.equal(thirdBook.bookId, 103);
+    assert.equal(thirdBook, selectBook(initialState, { bookId: 103 }));
+    assert.equal(fourthBook.bookId, 104);
+    assert.equal(fourthBook, selectBook(initialState, { bookId: 104 }));
+  });
+
+  it('should not rerun the root selector when nothing has changed', () => {
+    const author1 = selectAuthor(initialState, { authorId: 1 });
+
+    assert.equal(selectAuthor.getCallCountForParams({ authorId: 1 }), 1);
+    assert.equal(selectAuthor.getRecomputationsForParams({ authorId: 1 }), 0);
+    assert.equal(selectRawAuthorData.getCallCountForParams(1), 1);
+    assert.equal(selectRawAuthorData.getRecomputationsForParams(1), 0);
+
+    selectAuthor(initialState, { authorId: 1 });
+    selectAuthor(initialState, { authorId: 1 });
+    const author2 = selectAuthor(initialState, { authorId: 1 });
+
+    // selectAuthor got called 3 new times, but with no change.
+    // Nothing else got run.
+    assert.equal(selectAuthor.getCallCountForParams({ authorId: 1 }), 4);
+    assert.equal(selectAuthor.getRecomputationsForParams({ authorId: 1 }), 0);
+    assert.equal(selectRawAuthorData.getCallCountForParams(1), 1);
+    assert.equal(selectRawAuthorData.getRecomputationsForParams(1), 0);
+
+    assert.equal(author1, author2);
+  });
+
+  it('should not rerun the intermediate selector when the root selector has nothing really new', () => {
+    const author1 = selectAuthor(initialState, { authorId: 1 });
+
+    const state2 = {
+      ...initialState,
+      authorDataById: {
+        ...initialState.authorDataById,
+        1: { // make a new object, for no good reason
+          ...initialState.authorDataById[1],
+        },
+      },
+    };
+    const author2 = selectAuthor(state2, { authorId: 1 });
+
+    // selectAuthor got called once, but didn't recompute, while the root selector was re-run fully.
+    assert.equal(selectAuthor.getCallCountForParams({ authorId: 1 }), 2);
+    assert.equal(selectAuthor.getRecomputationsForParams({ authorId: 1 }), 0);
+    assert.equal(selectRawAuthorData.getCallCountForParams(1), 2);
+    assert.equal(selectRawAuthorData.getRecomputationsForParams(1), 1);
+    assert.equal(author1, author2);
+  });
+
+  it('should return the author for a book', () => {
+    const author1 = selectAuthorForBook(initialState, { bookId: 101 });
+    const author2 = selectAuthorForBook(initialState, { bookId: 102 });
+    const author3 = selectAuthorForBook(initialState, { bookId: 103 });
+    const author4 = selectAuthorForBook(initialState, { bookId: 104 });
+
+    assert.equal(author1.authorId, 1);
+    assert.equal(author1, selectAuthorForBook(initialState, { bookId: 101 }));
+    assert.equal(author2.authorId, 2);
+    assert.equal(author2, selectAuthorForBook(initialState, { bookId: 102 }));
+    assert.equal(author3.authorId, 1);
+    assert.equal(author3, selectAuthorForBook(initialState, { bookId: 103 }));
+    assert.equal(author4.authorId, 2);
+    assert.equal(author4, selectAuthorForBook(initialState, { bookId: 104 }));
+
+    assert.equal(author1, author3);
+    assert.equal(author2, author4);
+  });
+
+  it('should not re-run intermediate selectors when nothing has changed', () => {
+    const author1 = selectAuthorForBook(initialState, { bookId: 101 });
+
+    assert.equal(selectAuthorForBook.getCallCountForParams({ bookId: 101 }), 1);
+    assert.equal(selectAuthorForBook.getRecomputationsForParams({ bookId: 101 }), 0);
+    assert.equal(selectBook.getCallCountForParams({ bookId: 101 }), 1);
+    assert.equal(selectBook.getRecomputationsForParams({ bookId: 101 }), 0);
+    assert.equal(selectRawBookData.getCallCountForParams(101), 1);
+    assert.equal(selectRawBookData.getRecomputationsForParams(101), 0);
+    assert.equal(selectAuthor.getCallCountForParams({ authorId: 1 }), 1);
+    assert.equal(selectAuthor.getRecomputationsForParams({ authorId: 1 }), 0);
+    assert.equal(selectRawAuthorData.getCallCountForParams(1), 1);
+    assert.equal(selectRawAuthorData.getRecomputationsForParams(1), 0);
+
+    selectAuthorForBook(initialState, { bookId: 101 });
+    selectAuthorForBook(initialState, { bookId: 101 });
+    const author2 = selectAuthorForBook(initialState, { bookId: 101 });
+
+    // selectAuthor got called 3 new times, but with no change.
+    // Nothing else got run.
+    assert.equal(selectAuthorForBook.getCallCountForParams({ bookId: 101 }), 4);
+    assert.equal(selectAuthorForBook.getRecomputationsForParams({ bookId: 101 }), 0);
+    assert.equal(selectBook.getCallCountForParams({ bookId: 101 }), 1);
+    assert.equal(selectBook.getRecomputationsForParams({ bookId: 101 }), 0);
+    assert.equal(selectRawBookData.getCallCountForParams(101), 1);
+    assert.equal(selectRawBookData.getRecomputationsForParams(101), 0);
+    assert.equal(selectAuthor.getCallCountForParams({ authorId: 1 }), 1);
+    assert.equal(selectAuthor.getRecomputationsForParams({ authorId: 1 }), 0);
+    assert.equal(selectRawAuthorData.getCallCountForParams(1), 1);
+    assert.equal(selectRawAuthorData.getRecomputationsForParams(1), 0);
+
+    assert.equal(author1, author2);
+  });
+
+  it('should not rerun the topmost selector when the intermediate and root selectors have nothing really new', () => {
+    const author1 = selectAuthorForBook(initialState, { bookId: 101 });
+
+    const state2 = {
+      ...initialState,
+      bookDataById: {
+        ...initialState.bookDataById,
+        101: { // make a new object, for no good reason
+          ...initialState.bookDataById[101],
+        },
+      },
+    };
+    const author2 = selectAuthorForBook(state2, { bookId: 101 });
+
+    // selectAuthor got called once, but didn't recompute, while the book root selector was re-run fully.
+    assert.equal(selectAuthorForBook.getCallCountForParams({ bookId: 101 }), 2);
+    assert.equal(selectAuthorForBook.getRecomputationsForParams({ bookId: 101 }), 0);
+    assert.equal(selectBook.getCallCountForParams({ bookId: 101 }), 2);
+    assert.equal(selectBook.getRecomputationsForParams({ bookId: 101 }), 0);
+    assert.equal(selectRawBookData.getCallCountForParams(101), 2);
+    assert.equal(selectRawBookData.getRecomputationsForParams(101), 1);
+    assert.equal(selectAuthor.getCallCountForParams({ authorId: 1 }), 2);
+    assert.equal(selectAuthor.getRecomputationsForParams({ authorId: 1 }), 0);
+    assert.equal(selectRawAuthorData.getCallCountForParams(1), 2);
+    assert.equal(selectRawAuthorData.getRecomputationsForParams(1), 1);
+    assert.equal(author1, author2);
+
+    const state3 = {
+      ...state2,
+      bookDataById: {
+        ...state2.bookDataById,
+        101: { // new title!
+          ...state2.bookDataById[101],
+          title: 'ABC',
+        },
+      },
+    };
+    const author3 = selectAuthorForBook(state3, { bookId: 101 });
+
+    // All the ones that touch book data re-run, but the resulting author is unchanged
+    assert.equal(selectAuthorForBook.getCallCountForParams({ bookId: 101 }), 3);
+    assert.equal(selectAuthorForBook.getRecomputationsForParams({ bookId: 101 }), 1);
+    assert.equal(selectBook.getCallCountForParams({ bookId: 101 }), 4); // this is touched twice
+    assert.equal(selectBook.getRecomputationsForParams({ bookId: 101 }), 1);
+    assert.equal(selectRawBookData.getCallCountForParams(101), 4);
+    assert.equal(selectRawBookData.getRecomputationsForParams(101), 2);
+    assert.equal(selectAuthor.getCallCountForParams({ authorId: 1 }), 3);
+    assert.equal(selectAuthor.getRecomputationsForParams({ authorId: 1 }), 0);
+    assert.equal(selectRawAuthorData.getCallCountForParams(1), 3);
+    assert.equal(selectRawAuthorData.getRecomputationsForParams(1), 2);
+    assert.equal(author1, author3);
+  });
+});


### PR DESCRIPTION
This migrates the `recomputations` counter into the selector's closure, so that each one gets its own value, and adds a `callCount` for tracking the times we _could_ have run. Also added those two counters to be tracked by-paramKey (when performance logging is on) for better granularity.

Began adding a more end-to-end-ish integration test as well.